### PR TITLE
make composer non-interactive

### DIFF
--- a/base/Dockerfile-runtime
+++ b/base/Dockerfile-runtime
@@ -56,7 +56,9 @@ RUN zypper --non-interactive ref && zypper --non-interactive install --no-recomm
     && /usr/local/bin/composer-installer \
     && mkdir -p /srv/original_config/apps \
     && git clone --depth 5 https://github.com/maintaina-com/horde-deployment -b FRAMEWORK_6_0 /srv/www/horde \
-    && composer install -n ; composer clear-cache ; rm -rf /root/.composer/cache \
+    && composer --no-interaction install \
+    && composer --no-interaction clear-cache \
+    && rm -rf /root/.composer/cache \
     && chown -R wwwrun:www /srv/www/horde
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/base/bin/entrypoint.sh
+++ b/base/bin/entrypoint.sh
@@ -26,7 +26,7 @@ echo "export PATH=\$PATH:/srv/www/horde/vendor/bin" > /root/.bashrc
 if [[ ! -z $GITHUB_COMPOSER_TOKEN ]]
 then
     echo "Configuring authentication to Github API for composer"
-    composer config -g github-oauth.github.com $GITHUB_COMPOSER_TOKEN
+    composer --no-interaction config -g github-oauth.github.com $GITHUB_COMPOSER_TOKEN
 fi
 
 

--- a/groupware-webmail/Dockerfile-runtime
+++ b/groupware-webmail/Dockerfile-runtime
@@ -4,8 +4,8 @@ FROM ghcr.io/maintaina/containers/groupware:latest-runtime
 WORKDIR /srv/www/horde
 
 RUN --mount=type=secret,id=secrets,dst=/tmp/secrets.sh source /tmp/secrets.sh \
-    && composer require horde/imp "^7 || dev-FRAMEWORK_6_0" horde/ingo "^4 || dev-FRAMEWORK_6_0" horde/gollem "^4 || dev-FRAMEWORK_6_0"\
-    && composer clear-cache \
+    && composer --no-interaction require horde/imp "^7 || dev-FRAMEWORK_6_0" horde/ingo "^4 || dev-FRAMEWORK_6_0" horde/gollem "^4 || dev-FRAMEWORK_6_0"\
+    && composer --no-interaction clear-cache \
     && chown -R wwwrun:www /srv/www/horde \
     && unset COMPOSER_PAT
 

--- a/groupware/Dockerfile-runtime
+++ b/groupware/Dockerfile-runtime
@@ -4,8 +4,14 @@ FROM ghcr.io/maintaina/containers/base:latest-runtime
 WORKDIR /srv/www/horde
 
 RUN --mount=type=secret,id=secrets,dst=/tmp/secrets.sh source /tmp/secrets.sh \
-    && composer require horde/content "^3 || dev-FRAMEWORK_6_0" horde/passwd "^6 || dev-FRAMEWORK_6_0" horde/turba "^5 || dev-FRAMEWORK_6_0" horde/kronolith "^5 || dev-FRAMEWORK_6_0"  horde/nag "^5 || dev-FRAMEWORK_6_0" horde/mnemo "^5 || dev-FRAMEWORK_6_0" \
-    && composer clear-cache \
+    && composer --no-interaction require \
+        horde/content "^3 || dev-FRAMEWORK_6_0" \
+        horde/kronolith "^5 || dev-FRAMEWORK_6_0" \
+        horde/mnemo "^5 || dev-FRAMEWORK_6_0" \
+        horde/nag "^5 || dev-FRAMEWORK_6_0" \
+        horde/passwd "^6 || dev-FRAMEWORK_6_0" \
+        horde/turba "^5 || dev-FRAMEWORK_6_0" \
+    && composer --no-interaction clear-cache \
     && chown -R wwwrun:www /srv/www/horde/ \
     && unset COMPOSER_PAT
 


### PR DESCRIPTION
Problem:
When starting a container from image base:latest-apache, the entrypoint script gets stuck because composer asks for manual confirmation to run as root.

Solution: Always use composer with option `--no-interaction` in Dockerfiles, entrypoints, additional scripts etc.