### PR TITLE
Configure xdebug

### DIFF
--- a/base/bin/entrypoint.sh
+++ b/base/bin/entrypoint.sh
@@ -4,6 +4,7 @@ echo "Config stage"
 ## copy files from /srv/original_config/apps to config dirs
 /usr/local/bin/copy-original-configs
 
+# TODO: remove this section, docker-compose >= 1.26 supports quotes in .env
 ## FIXUP VARIABLES IF THEY CONTAIN LEADING/TRAILING QUOTES
 
 tmp="${GITHUB_COMPOSER_TOKEN%\"}"
@@ -21,9 +22,9 @@ export HORDE_ADMIN_PASSWORD=$tmp
 ## ADD composer bin_dir to PATH
 echo "export PATH=\$PATH:/srv/www/horde/vendor/bin" > /root/.bashrc
 
-if [[ ! -z $GITHUB_COMPOSER_TOKEN ]]; then
+if [[ -n $GITHUB_COMPOSER_TOKEN ]]; then
 	echo "Configuring authentication to Github API for composer"
-	composer --no-interaction config -g github-oauth.github.com $GITHUB_COMPOSER_TOKEN
+	composer --no-interaction config -g github-oauth.github.com "$GITHUB_COMPOSER_TOKEN"
 fi
 
 ## Replace some well-known template variables in the horde config
@@ -57,7 +58,7 @@ fi
 ## TODO: BACKGROUND THIS and everything besides making the main process pid 1
 ## Wait for DB connection to succeed
 ## TODO: Make this optional for No-DB scenarios
-if [[ ! -z $MYSQL_PASSWORD ]]; then
+if [[ -n $MYSQL_PASSWORD ]]; then
 	echo "SHOW DATABASES" >/root/conntest.sql
 	echo "WAITING FOR DB CONNECTION TO SUCCEED"
 	echo "For new setups, this may take some time. You may see error messages"
@@ -82,7 +83,7 @@ fi
 # Inject initial user or change his password if he already exists
 if [[ -v HORDE_ADMIN_USER ]]; then
 	echo "Injecting Admin User $HORDE_ADMIN_USER"
-	php /srv/www/horde/vendor/bin/hordectl patch user $HORDE_ADMIN_USER $HORDE_ADMIN_PASSWORD
+	php /srv/www/horde/vendor/bin/hordectl patch user "$HORDE_ADMIN_USER" "$HORDE_ADMIN_PASSWORD"
 fi
 
 # if ENABLE_DEVELOPER_MODE=yes then install the developer tools marked with yes (e.g. VIM=yes)
@@ -91,12 +92,30 @@ if [[ -v ENABLE_DEVELOPER_MODE && -n "$ENABLE_DEVELOPER_MODE" && $ENABLE_DEVELOP
 	PHP_VERSION=$(php -r "echo PHP_VERSION;")
 
 	if [[ $PHP_VERSION == 7.* ]]; then
-		zypper -n in php7-xdebug
+		zypper -n install php7-xdebug
 	fi
 	if [[ $PHP_VERSION == 8.* ]]; then
-		zypper -n in php8-xdebug
+		zypper -n install php8-xdebug
 	fi
-	zypper -n in vim wget mc iputils curl less bind-utils 	
+
+    xdebug_major_version="$(rpm -qa '*xdebug*' --qf "%{VERSION}\n" | cut -d'.' -f1)"
+    if [[ $xdebug_major_version -eq 2 ]]; then
+        # configuration for Xdebug 2.9.5 as distributed by openSUSE Leap 15.3
+        {
+            echo "xdebug.remote_enable = 1";
+            echo "xdebug.remote_autostart = 1";
+            echo "xdebug.remote_port = 9000";
+        } >> /etc/php7/conf.d/xdebug.ini
+    elif [[ $xdebug_major_version -eq 3 ]]; then
+        # NOTE: untested as of 2022-03-04, as only Tumbleweed has Xdebug 3
+        {
+            echo "xdebug.mode = develop,debug";
+            echo "xdebug.start_with_request = yes";
+        } >> /etc/php7/conf.d/xdebug.ini
+    fi
+    unset xdebug_major_version
+
+	zypper -n install vim vim-data wget mc iputils curl less bind-utils
 
 	echo "ending installation of developer-tools"
 else
@@ -106,7 +125,7 @@ fi
 # if CUSTOM_TOOLS is not empty try to install them
 if [[ -v CUSTOM_TOOLS && -n "$CUSTOM_TOOLS" ]]; then
 	echo "Custom tools to be installed: $CUSTOM_TOOLS"
-	zypper -n in $CUSTOM_TOOLS
+	zypper -n install "$CUSTOM_TOOLS"
 fi
 
 echo "Handing over to pid 1 command"

--- a/base/bin/entrypoint.sh
+++ b/base/bin/entrypoint.sh
@@ -23,58 +23,58 @@ export HORDE_ADMIN_PASSWORD=$tmp
 echo "export PATH=\$PATH:/srv/www/horde/vendor/bin" > /root/.bashrc
 
 if [[ -n $GITHUB_COMPOSER_TOKEN ]]; then
-	echo "Configuring authentication to Github API for composer"
-	composer --no-interaction config -g github-oauth.github.com "$GITHUB_COMPOSER_TOKEN"
+    echo "Configuring authentication to Github API for composer"
+    composer --no-interaction config -g github-oauth.github.com "$GITHUB_COMPOSER_TOKEN"
 fi
 
 ## Replace some well-known template variables in the horde config
 if [[ -v EXPAND_CONFIGS ]]; then
-	echo "EXPANDING CONFIG VARIABLES"
-	if [[ -v MYSQL_DATABASE ]]; then
-		echo
-		sed -i "s/conf\['sql'\]\['database'\].*/conf['sql']['database'] = '$MYSQL_DATABASE';/g" /srv/www/horde/web/horde/config/conf.php
-	fi
-	if [[ -v MYSQL_HOSTNAME ]]; then
-		echo
-		sed -i "s/conf\['sql'\]\['hostspec'\].*/conf['sql']['hostspec'] = '$MYSQL_HOSTNAME';/g" /srv/www/horde/web/horde/config/conf.php
-	fi
-	if [[ -v MYSQL_USER ]]; then
-		echo
-		sed -i "s/conf\['sql'\]\['username'\].*/conf['sql']['username'] = '$MYSQL_USER';/g" /srv/www/horde/web/horde/config/conf.php
-	fi
-	if [[ -v MYSQL_PASSWORD ]]; then
-		echo
-		sed -i "s/conf\['sql'\]\['password'\].*/conf['sql']['password'] = '$MYSQL_PASSWORD';/g" /srv/www/horde/web/horde/config/conf.php
-	fi
+    echo "EXPANDING CONFIG VARIABLES"
+    if [[ -v MYSQL_DATABASE ]]; then
+        echo
+        sed -i "s/conf\['sql'\]\['database'\].*/conf['sql']['database'] = '$MYSQL_DATABASE';/g" /srv/www/horde/web/horde/config/conf.php
+    fi
+    if [[ -v MYSQL_HOSTNAME ]]; then
+        echo
+        sed -i "s/conf\['sql'\]\['hostspec'\].*/conf['sql']['hostspec'] = '$MYSQL_HOSTNAME';/g" /srv/www/horde/web/horde/config/conf.php
+    fi
+    if [[ -v MYSQL_USER ]]; then
+        echo
+        sed -i "s/conf\['sql'\]\['username'\].*/conf['sql']['username'] = '$MYSQL_USER';/g" /srv/www/horde/web/horde/config/conf.php
+    fi
+    if [[ -v MYSQL_PASSWORD ]]; then
+        echo
+        sed -i "s/conf\['sql'\]\['password'\].*/conf['sql']['password'] = '$MYSQL_PASSWORD';/g" /srv/www/horde/web/horde/config/conf.php
+    fi
 fi
 
 ## if a composer-on-bootstrap.sh hook exists, run it
 ## The hook should take care itself if it should only run for the very first startup.
 if [[ -f "/usr/local/bin/composer-on-bootstrap" ]]; then
-	echo "Found composer-on-bootstrap. Running ..."
-	/usr/local/bin/composer-on-bootstrap
+    echo "Found composer-on-bootstrap. Running ..."
+    /usr/local/bin/composer-on-bootstrap
 fi
 
 ## TODO: BACKGROUND THIS and everything besides making the main process pid 1
 ## Wait for DB connection to succeed
 ## TODO: Make this optional for No-DB scenarios
-if [[ -n $MYSQL_PASSWORD ]]; then
-	echo "SHOW DATABASES" >/root/conntest.sql
-	echo "WAITING FOR DB CONNECTION TO SUCCEED"
-	echo "For new setups, this may take some time. You may see error messages"
-	until php /srv/www/horde/web/horde/bin/horde-sql-shell /root/conntest.sql &>/dev/null; do
-		sleep 3
-		echo "RETRYING"
-	done
-	echo "CONNECTION ESTABLISHED"
+if [[ -n "$MYSQL_PASSWORD" ]]; then
+    echo "SHOW DATABASES" >/root/conntest.sql
+    echo "WAITING FOR DB CONNECTION TO SUCCEED"
+    echo "For new setups, this may take some time. You may see error messages"
+    until php /srv/www/horde/web/horde/bin/horde-sql-shell /root/conntest.sql &>/dev/null; do
+        sleep 3
+        echo "RETRYING"
+    done
+    echo "CONNECTION ESTABLISHED"
 fi
 
 ## Run migrations N times
 if [[ -v HORDE_MIGRATION_RUNS ]]; then
-	for ((i = 1; i <= HORDE_MIGRATION_RUNS; i++)); do
-		echo "Running Horde Schema Migrations: #$i"
-		php /srv/www/horde/web/horde/bin/horde-db-migrate
-	done
+    for ((i = 1; i <= HORDE_MIGRATION_RUNS; i++)); do
+        echo "Running Horde Schema Migrations: #$i"
+        php /srv/www/horde/web/horde/bin/horde-db-migrate
+    done
 fi
 
 ## if hordectl is installed and /srv/original_config/hordectl exists, run all yml files through it
@@ -82,21 +82,21 @@ fi
 
 # Inject initial user or change his password if he already exists
 if [[ -v HORDE_ADMIN_USER ]]; then
-	echo "Injecting Admin User $HORDE_ADMIN_USER"
-	php /srv/www/horde/vendor/bin/hordectl patch user "$HORDE_ADMIN_USER" "$HORDE_ADMIN_PASSWORD"
+    echo "Injecting Admin User $HORDE_ADMIN_USER"
+    php /srv/www/horde/vendor/bin/hordectl patch user "$HORDE_ADMIN_USER" "$HORDE_ADMIN_PASSWORD"
 fi
 
 # if ENABLE_DEVELOPER_MODE=yes then install the developer tools marked with yes (e.g. VIM=yes)
 if [[ -v ENABLE_DEVELOPER_MODE && -n "$ENABLE_DEVELOPER_MODE" && $ENABLE_DEVELOPER_MODE == "yes" ]]; then
-	echo "developer-mode is enabled: starting installation of developer-tools"
-	PHP_VERSION=$(php -r "echo PHP_VERSION;")
+    echo "developer-mode is enabled: starting installation of developer-tools"
+    PHP_VERSION=$(php -r "echo PHP_VERSION;")
 
-	if [[ $PHP_VERSION == 7.* ]]; then
-		zypper -n install php7-xdebug
-	fi
-	if [[ $PHP_VERSION == 8.* ]]; then
-		zypper -n install php8-xdebug
-	fi
+    if [[ $PHP_VERSION == 7.* ]]; then
+        zypper -n install php7-xdebug
+    fi
+    if [[ $PHP_VERSION == 8.* ]]; then
+        zypper -n install php8-xdebug
+    fi
 
     xdebug_major_version="$(rpm -qa '*xdebug*' --qf "%{VERSION}\n" | cut -d'.' -f1)"
     if [[ $xdebug_major_version -eq 2 ]]; then
@@ -115,17 +115,17 @@ if [[ -v ENABLE_DEVELOPER_MODE && -n "$ENABLE_DEVELOPER_MODE" && $ENABLE_DEVELOP
     fi
     unset xdebug_major_version
 
-	zypper -n install vim vim-data wget mc iputils curl less bind-utils
+    zypper -n install vim vim-data wget mc iputils curl less bind-utils
 
-	echo "ending installation of developer-tools"
+    echo "ending installation of developer-tools"
 else
-	echo "developer-mode is disabled: no installation of dev-tools"
+    echo "developer-mode is disabled: no installation of dev-tools"
 fi
 
 # if CUSTOM_TOOLS is not empty try to install them
 if [[ -v CUSTOM_TOOLS && -n "$CUSTOM_TOOLS" ]]; then
-	echo "Custom tools to be installed: $CUSTOM_TOOLS"
-	zypper -n install "$CUSTOM_TOOLS"
+    echo "Custom tools to be installed: $CUSTOM_TOOLS"
+    zypper -n install "$CUSTOM_TOOLS"
 fi
 
 echo "Handing over to pid 1 command"


### PR DESCRIPTION
PR #4 introduced a developer mode which installs Xdebug, but does not configure it. This is a continuation which extends the entrypoint to configure Xdebug ready to use for PHP debugging when the container finishes startup.

Supported are Xdebug version 2.9.* used by openSUSE Leap and Xdebug version 3 used by Tumbleweed. The configuration will be run only if developer mode is enabled.