### PR TITLE
[dovecot] adapt path of tini executable due to Debian base image update

### DIFF
--- a/dovecot/Dockerfile
+++ b/dovecot/Dockerfile
@@ -1,6 +1,10 @@
 FROM docker.io/dovecot/dovecot:latest
+
 COPY ./dovecot /etc/dovecot
 COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
+
 RUN chmod +x /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+
 CMD ["/usr/sbin/dovecot", "-F"]


### PR DESCRIPTION
The latest image of Dovecot switch from Debian Buster to Debian Bullseye. Due to this, the location of the tini executable changed from `/sbin` to `/usr/bin`.